### PR TITLE
Weird bug caused by trailing forward slash

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,12 @@ Have a nice day!
 <!-- Search Engine Optimizations -->
 <title>Dr. Κωνσταντίνος Α. Τουλής | Eνδοκρινολογία - Σακχαρώδης Διαβήτης - Μεταβολισμός</title>
 <meta name="description" content="Eνδοκρινολογία - Σακχαρώδης Διαβήτης - Μεταβολισμός">
-<link rel="canonical" href="https://toulis.gr/" />
+<link rel="canonical" href="https://toulis.gr" />
 <meta property="go:locale" content="el-GR" />
 <!-- Open graph -->
 <meta property="og:title" content="Dr. Κωνσταντίνος Α. Τουλής | Eνδοκρινολογία - Σακχαρώδης Διαβήτης - Μεταβολισμός" />
 <meta property="og:description" content="Eνδοκρινολογία - Σακχαρώδης Διαβήτης - Μεταβολισμός" />
-<meta property="go:url" content="https://toulis.gr/" />
+<meta property="go:url" content="https://toulis.gr" />
 <meta property="og:site_name" content="Dr. Κωνσταντίνος Α. Τουλής | Eνδοκρινολογία - Σακχαρώδης Διαβήτης - Μεταβολισμός" />
 <meta property="go:image" content="images/toulis-logo-OG-250.jpg"/>
 <meta property="go:image:type" content="image/jpeg">


### PR DESCRIPTION
Clicking on the main menu's logo produces a 404 error. 
Not just that, it also directs to toulis.gr/...

As a first step, we've removed the forward slash.
NExt step is to edit the two URL's so that they include HTTP instead of HTTPS.